### PR TITLE
Add new math functions

### DIFF
--- a/include/TinyAD/Scalar.hh
+++ b/include/TinyAD/Scalar.hh
@@ -775,9 +775,9 @@ struct Scalar
             const Scalar& b)
     {
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(x);
-        if(x < a)
+        if (x < a)
             return a;
-        else if(x > b)
+        else if (x > b)
             return b;
         else
             return x;

--- a/include/TinyAD/Scalar.hh
+++ b/include/TinyAD/Scalar.hh
@@ -229,6 +229,32 @@ struct Scalar
                     a);
     }
 
+    friend Scalar log2(
+            const Scalar& a)
+    {
+        TINYAD_CHECK_FINITE_IF_ENABLED_AD(a);
+        if constexpr (TINYAD_ENABLE_OPERATOR_LOGGING) TINYAD_DEBUG_VAR(__FUNCTION__);
+        const PassiveT a_inv = (PassiveT)1.0 / a.val / std::log(2.0);
+        return chain(
+                    std::log2(a.val),
+                    a_inv,
+                    -a_inv / a.val,
+                    a);
+    }
+
+    friend Scalar log10(
+            const Scalar& a)
+    {
+        TINYAD_CHECK_FINITE_IF_ENABLED_AD(a);
+        if constexpr (TINYAD_ENABLE_OPERATOR_LOGGING) TINYAD_DEBUG_VAR(__FUNCTION__);
+        const PassiveT a_inv = (PassiveT)1.0 / a.val / std::log(10.0);
+        return chain(
+                    std::log10(a.val),
+                    a_inv,
+                    -a_inv / a.val,
+                    a);
+    }
+
     friend Scalar sin(
             const Scalar& a)
     {
@@ -741,6 +767,20 @@ struct Scalar
             const Scalar& b)
     {
         return max(a, b);
+    }
+
+    friend Scalar clamp(
+            const Scalar& x,
+            const Scalar& a,
+            const Scalar& b)
+    {
+        TINYAD_CHECK_FINITE_IF_ENABLED_AD(x);
+        if(x < a)
+            return a;
+        else if(x > b)
+            return b;
+        else
+            return x;
     }
 
     // ///////////////////////////////////////////////////////////////////////////

--- a/tests/ScalarTest.cc
+++ b/tests/ScalarTest.cc
@@ -1319,6 +1319,13 @@ void test_comparison()
     ASSERT_FALSE(a >= 2.0);
 }
 
+TEST(ScalarTest, ComparisonFloatFirstOrder) { test_comparison<float, false>(); }
+TEST(ScalarTest, ComparisonDoubleFirstOrder) { test_comparison<double, false>(); }
+TEST(ScalarTest, ComparisonLongDoubleFirstOrder) { test_comparison<long double, false>(); }
+TEST(ScalarTest, ComparisonFloatSecondOrder) { test_comparison<float, true>(); }
+TEST(ScalarTest, ComparisonDoubleSecondOrder) { test_comparison<double, true>(); }
+TEST(ScalarTest, ComparisonLongDoubleSecondOrder) { test_comparison<long double, true>(); }
+
 template <typename PassiveT>
 void test_min_max()
 {
@@ -1347,7 +1354,7 @@ TEST(ScalarTest, MinMaxDouble) { test_min_max<double>(); }
 TEST(ScalarTest, MinMaxLongDouble) { test_min_max<long double>(); }
 
 template <typename PassiveT>
-void test_min_max()
+void test_clamp()
 {
     TinyAD::Scalar<1, PassiveT, with_hessian> x(4.0, 3.0, 2.0);
 
@@ -1364,16 +1371,9 @@ void test_min_max()
     ASSERT_EQ(clamp(x, 5.0, 10.0).Hess(0, 0), 0.0);
 }
 
-TEST(ScalarTest, MinMaxFloat) { test_min_max<float>(); }
-TEST(ScalarTest, MinMaxDouble) { test_min_max<double>(); }
-TEST(ScalarTest, MinMaxLongDouble) { test_min_max<long double>(); }
-
-TEST(ScalarTest, ComparisonFloatFirstOrder) { test_comparison<float, false>(); }
-TEST(ScalarTest, ComparisonDoubleFirstOrder) { test_comparison<double, false>(); }
-TEST(ScalarTest, ComparisonLongDoubleFirstOrder) { test_comparison<long double, false>(); }
-TEST(ScalarTest, ComparisonFloatSecondOrder) { test_comparison<float, true>(); }
-TEST(ScalarTest, ComparisonDoubleSecondOrder) { test_comparison<double, true>(); }
-TEST(ScalarTest, ComparisonLongDoubleSecondOrder) { test_comparison<long double, true>(); }
+TEST(ScalarTest, MinMaxFloat) { test_clamp<float>(); }
+TEST(ScalarTest, MinMaxDouble) { test_clamp<double>(); }
+TEST(ScalarTest, MinMaxLongDouble) { test_clamp<long double>(); }
 
 template <typename PassiveT, bool with_hessian>
 void test_sphere()

--- a/tests/ScalarTest.cc
+++ b/tests/ScalarTest.cc
@@ -368,6 +368,50 @@ TEST(ScalarTest, LogDoubleSecondOrder) { test_log<double, true>(1e-12); }
 TEST(ScalarTest, LogLongDoubleSecondOrder) { test_log<long double, true>(1e-12); }
 
 template <typename PassiveT, bool with_hessian>
+void test_log2(const PassiveT _eps)
+{
+    // a(x) = x^2 + x + 2 at x=1
+    TinyAD::Scalar<1, PassiveT, with_hessian> a(4.0, 3.0, 2.0);
+    const auto f = log2(a);
+    ASSERT_NEAR(f.val, 2.0, _eps);
+    ASSERT_NEAR(f.grad(0), 3.0 / 4.0 / std::log(2.0), _eps);
+    if constexpr (with_hessian)
+    {
+        ASSERT_NEAR(f.Hess(0, 0), -1.0 / 16.0 / std::log(2.0), _eps);
+        TINYAD_ASSERT_SYMMETRIC(f.Hess, _eps);
+    }
+}
+
+TEST(ScalarTest, Log2FloatFirstOrder) { test_log2<float, false>(1e-4f); }
+TEST(ScalarTest, Log2DoubleFirstOrder) { test_log2<double, false>(1e-12); }
+TEST(ScalarTest, Log2LongDoubleFirstOrder) { test_log2<long double, false>(1e-12); }
+TEST(ScalarTest, Log2FloatSecondOrder) { test_log2<float, true>(1e-4f); }
+TEST(ScalarTest, Log2DoubleSecondOrder) { test_log2<double, true>(1e-12); }
+TEST(ScalarTest, Log2LongDoubleSecondOrder) { test_log2<long double, true>(1e-12); }
+
+template <typename PassiveT, bool with_hessian>
+void test_log10(const PassiveT _eps)
+{
+    // a(x) = x^2 + x + 2 at x=1
+    TinyAD::Scalar<1, PassiveT, with_hessian> a(4.0, 3.0, 2.0);
+    const auto f = log10(a);
+    ASSERT_NEAR(f.val, std::log10(4.0), _eps);
+    ASSERT_NEAR(f.grad(0), 3.0 / 4.0 / std::log(10.0), _eps);
+    if constexpr (with_hessian)
+    {
+        ASSERT_NEAR(f.Hess(0, 0), -1.0 / 16.0 / std::log(10.0), _eps);
+        TINYAD_ASSERT_SYMMETRIC(f.Hess, _eps);
+    }
+}
+
+TEST(ScalarTest, Log10FloatFirstOrder) { test_log10<float, false>(1e-4f); }
+TEST(ScalarTest, Log10DoubleFirstOrder) { test_log10<double, false>(1e-12); }
+TEST(ScalarTest, Log10LongDoubleFirstOrder) { test_log10<long double, false>(1e-12); }
+TEST(ScalarTest, Log10FloatSecondOrder) { test_log10<float, true>(1e-4f); }
+TEST(ScalarTest, Log10DoubleSecondOrder) { test_log10<double, true>(1e-12); }
+TEST(ScalarTest, Log10LongDoubleSecondOrder) { test_log10<long double, true>(1e-12); }
+
+template <typename PassiveT, bool with_hessian>
 void test_sin(const PassiveT _eps)
 {
     // a(x) = x^2 + x + 2 at x=1
@@ -1296,6 +1340,28 @@ void test_min_max()
     ASSERT_EQ(fmax(a, b), b);
     ASSERT_EQ(fmax(a, b).grad, b.grad);
     ASSERT_EQ(fmax(a, b).Hess, b.Hess);
+}
+
+TEST(ScalarTest, MinMaxFloat) { test_min_max<float>(); }
+TEST(ScalarTest, MinMaxDouble) { test_min_max<double>(); }
+TEST(ScalarTest, MinMaxLongDouble) { test_min_max<long double>(); }
+
+template <typename PassiveT>
+void test_min_max()
+{
+    TinyAD::Scalar<1, PassiveT, with_hessian> x(4.0, 3.0, 2.0);
+
+    ASSERT_EQ(clamp(x, 0.0, 5.0), x);
+    ASSERT_EQ(clamp(x, 0.0, 5.0).grad, x.grad);
+    ASSERT_EQ(clamp(x, 0.0, 5.0).Hess, x.Hess);
+
+    ASSERT_EQ(clamp(x, -5.0, 0.0), 0.0);
+    ASSERT_EQ(clamp(x, -5.0, 0.0).grad(0), 0.0);
+    ASSERT_EQ(clamp(x, -5.0, 0.0).Hess(0, 0), 0.0);
+
+    ASSERT_EQ(clamp(x, 5.0, 10.0), 5.0);
+    ASSERT_EQ(clamp(x, 5.0, 10.0).grad(0), 0.0);
+    ASSERT_EQ(clamp(x, 5.0, 10.0).Hess(0, 0), 0.0);
 }
 
 TEST(ScalarTest, MinMaxFloat) { test_min_max<float>(); }

--- a/tests/ScalarTest.cc
+++ b/tests/ScalarTest.cc
@@ -1356,7 +1356,7 @@ TEST(ScalarTest, MinMaxLongDouble) { test_min_max<long double>(); }
 template <typename PassiveT>
 void test_clamp()
 {
-    TinyAD::Scalar<1, PassiveT, with_hessian> x(4.0, 3.0, 2.0);
+    TinyAD::Scalar<1, PassiveT> x(4.0, 3.0, 2.0);
 
     ASSERT_EQ(clamp(x, 0.0, 5.0), x);
     ASSERT_EQ(clamp(x, 0.0, 5.0).grad, x.grad);
@@ -1371,9 +1371,9 @@ void test_clamp()
     ASSERT_EQ(clamp(x, 5.0, 10.0).Hess(0, 0), 0.0);
 }
 
-TEST(ScalarTest, MinMaxFloat) { test_clamp<float>(); }
-TEST(ScalarTest, MinMaxDouble) { test_clamp<double>(); }
-TEST(ScalarTest, MinMaxLongDouble) { test_clamp<long double>(); }
+TEST(ScalarTest, ClampFloat) { test_clamp<float>(); }
+TEST(ScalarTest, ClampDouble) { test_clamp<double>(); }
+TEST(ScalarTest, ClampLongDouble) { test_clamp<long double>(); }
 
 template <typename PassiveT, bool with_hessian>
 void test_sphere()


### PR DESCRIPTION
Thank you very much for releasing this library! As someone who spent endless hours deriving hessian formulas by hand I can say this is clearly a big help :)

I've added some math functions (clamp, log2, log10) that were missing from the library, they are listed as common math functions here: https://en.cppreference.com/w/cpp/numeric/math 
I wrote some tests for each function, but unfortunately I didn't find a way to build the tests (there's an error with ```StackLowerThanAddress``` function on gtest-1.10.0) so I could not check that the functions pass the tests unfortunately.

Anyways I've used them in a personal project and they seemed to work fine so I hope this helps