### PR TITLE
Merge Hessian Sub-Block Feature

### DIFF
--- a/include/TinyAD/Scalar.hh
+++ b/include/TinyAD/Scalar.hh
@@ -19,20 +19,31 @@ namespace TinyAD
   *     k: Size of variable vector at compile time. (Eigen::Dynamic is possible, but experimental and slow.)
   *     PassiveT: Internal floating point type, e.g. double.
   *     with_hessian: Set to false for gradient-only mode.
+  *     hess_row_start, hess_col_start, hess_rows, hess_cols: Restrict Hessian computation to a sub-block
   */
-template <int k, typename PassiveT, bool with_hessian = true>
+template <int k, typename PassiveT, bool with_hessian = true, int hess_row_start = 0, int hess_col_start = 0, int hess_rows = k, int hess_cols = k>
 struct Scalar
 {
     // Make template arguments available as members
     static constexpr int k_ = k;
     static constexpr bool with_hessian_ = with_hessian;
     static constexpr bool dynamic_mode_ = k == Eigen::Dynamic;
+    static constexpr bool truncated_hessian_ = hess_row_start != 0 || hess_col_start != 0 || hess_rows != k || hess_cols != k;
 
-    // Determine derivative data types at compile time. Use 0-by-0 if no Hessian required.
+    // Validate template arguments
+    static_assert (k_ >= 0 || k_ == Eigen::Dynamic, "Variable dimension k has to be non-negative or Eigen::Dynamic.");
+    static_assert (!truncated_hessian_ || with_hessian_, "with_hessian needs to be true when restricting Hessian to a sub-block.");
+    static_assert (!(dynamic_mode_ && truncated_hessian_), "Truncated Hessian is not supported in dynamic mode.");
+    static_assert (!truncated_hessian_ || (hess_row_start >= 0 && hess_rows >= 0 && hess_row_start + hess_rows <= k), "Selected Hessian block has to be <= k-by-k");
+    static_assert (!truncated_hessian_ || (hess_col_start >= 0 && hess_cols >= 0 && hess_col_start + hess_cols <= k), "Selected Hessian block has to be <= k-by-k");
+
+    // Determine derivative data types at compile time.
+    // Use 0-by-0 if no Hessian required.
+    // Hessian might be truncated to a (rectangular) block smaller than k-by-k.
     using GradType = Eigen::Matrix<PassiveT, k, 1>;
     using HessType = typename std::conditional_t<
                 with_hessian,
-                Eigen::Matrix<PassiveT, k, k>,
+                Eigen::Matrix<PassiveT, hess_rows, hess_cols>,
                 Eigen::Matrix<PassiveT, 0, 0>>;
 
     // ///////////////////////////////////////////////////////////////////////////
@@ -169,8 +180,20 @@ struct Scalar
     }
 
     // ///////////////////////////////////////////////////////////////////////////
-    // Unary operators
+    // Convenience functions
     // ///////////////////////////////////////////////////////////////////////////
+
+    /// Compute outer product grad_a * grad_b^T, restricted to a specific block.
+    /// The result is a (possibly rectangular) matrix of size less or equal than k-by-k.
+    static auto outer(
+            const GradType& grad_a, // size k
+            const GradType& grad_b) // size k
+    {
+        if constexpr (truncated_hessian_)
+            return grad_a.template segment<hess_rows>(hess_row_start) * grad_b.template segment<hess_cols>(hess_col_start).transpose();
+        else
+            return grad_a * grad_b.transpose(); // This line is here to not break dynamic mode
+    }
 
     /// Apply chain rule to compute f(a(x)) and its derivatives.
     static Scalar chain(
@@ -184,11 +207,15 @@ struct Scalar
         res.grad = grad * a.grad;
 
         if constexpr (with_hessian)
-            res.Hess = Hess * a.grad * a.grad.transpose() + grad * a.Hess;
+            res.Hess = Hess * outer(a.grad, a.grad) + grad * a.Hess; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
     }
+
+    // ///////////////////////////////////////////////////////////////////////////
+    // Unary operators
+    // ///////////////////////////////////////////////////////////////////////////
 
     friend Scalar operator-(
             const Scalar& a)
@@ -230,7 +257,7 @@ struct Scalar
         res.grad = 2.0 * a.val * a.grad;
 
         if constexpr (with_hessian)
-            res.Hess = 2.0 * (a.val * a.Hess + a.grad * a.grad.transpose());
+            res.Hess = 2.0 * (a.val * a.Hess + outer(a.grad, a.grad)); // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -554,7 +581,7 @@ struct Scalar
         res.grad = a.grad + b.grad;
 
         if constexpr (with_hessian)
-            res.Hess = a.Hess + b.Hess;
+            res.Hess = a.Hess + b.Hess; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -599,7 +626,7 @@ struct Scalar
         this->val += b.val;
         this->grad += b.grad;
         if constexpr (with_hessian)
-            this->Hess += b.Hess;
+            this->Hess += b.Hess; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(*this);
         return *this;
@@ -631,7 +658,7 @@ struct Scalar
         res.grad = a.grad - b.grad;
 
         if constexpr (with_hessian)
-            res.Hess = a.Hess - b.Hess;
+            res.Hess = a.Hess - b.Hess; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -663,7 +690,7 @@ struct Scalar
         res.grad = -b.grad;
 
         if constexpr (with_hessian)
-            res.Hess = -b.Hess;
+            res.Hess = -b.Hess; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -681,7 +708,7 @@ struct Scalar
         this->grad -= b.grad;
 
         if constexpr (with_hessian)
-            this->Hess -= b.Hess;
+            this->Hess -= b.Hess; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(*this);
         return *this;
@@ -725,8 +752,8 @@ struct Scalar
 //            res.Hess = res.Hess.template selfadjointView<Eigen::Lower>();
 //        }
 
-        if constexpr (with_hessian)
-            res.Hess = b.val * a.Hess + a.grad * b.grad.transpose() + b.grad * a.grad.transpose() + a.val * b.Hess;
+        if constexpr (with_hessian) // Might be a Hessian block only!
+            res.Hess = b.val * a.Hess + outer(a.grad, b.grad) + outer(b.grad, a.grad) + a.val * b.Hess;
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -745,7 +772,7 @@ struct Scalar
         res.grad *= b;
 
         if constexpr (with_hessian)
-            res.Hess *= b;
+            res.Hess *= b; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -764,7 +791,7 @@ struct Scalar
         res.grad *= a;
 
         if constexpr (with_hessian)
-            res.Hess *= a;
+            res.Hess *= a; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -797,8 +824,8 @@ struct Scalar
         res.val = a.val / b.val;
         res.grad = (b.val * a.grad - a.val * b.grad) / (b.val * b.val);
 
-        if constexpr (with_hessian)
-            res.Hess = (a.Hess - res.grad * b.grad.transpose() - b.grad * res.grad.transpose() - res.val * b.Hess) / b.val;
+        if constexpr (with_hessian) // Might be a Hessian block only!
+            res.Hess = (a.Hess - outer(res.grad, b.grad) - outer(b.grad, res.grad) - res.val * b.Hess) / b.val;
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -816,7 +843,7 @@ struct Scalar
         res.grad /= b;
 
         if constexpr (with_hessian)
-            res.Hess /= b;
+            res.Hess /= b; // Might be a Hessian block only!
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -833,8 +860,8 @@ struct Scalar
         res.val = a / b.val;
         res.grad = (-a / (b.val * b.val)) * b.grad;
 
-        if constexpr (with_hessian)
-            res.Hess = (-res.grad * b.grad.transpose() - b.grad * res.grad.transpose() - res.val * b.Hess) / b.val;
+        if constexpr (with_hessian) // Might be a Hessian block only!
+            res.Hess = (outer(-res.grad, b.grad) - outer(b.grad, res.grad) - res.val * b.Hess) / b.val;
 
         TINYAD_CHECK_FINITE_IF_ENABLED_AD(res);
         return res;
@@ -872,7 +899,8 @@ struct Scalar
 
         if constexpr (with_hessian)
         {
-            const HessType du = x.val * y.Hess - y.val * x.Hess + y.grad * x.grad.transpose() - x.grad * y.grad.transpose();
+            // Might be a Hessian block only!
+            const HessType du = x.val * y.Hess - y.val * x.Hess + outer(y.grad, x.grad) - outer(x.grad, y.grad);
             const GradType dv = (PassiveT)2.0 * (x.val * x.grad + y.val * y.grad);
             res.Hess = (du - res.grad * dv.transpose()) / v;
         }
@@ -1304,9 +1332,9 @@ struct Scalar
     PassiveT val = 0.0;                // Scalar value of this (intermediate) variable.
     GradType grad = GradType::Zero(    // Gradient (first derivative) of val w.r.t. the active variable vector.
                 dynamic_mode_ ? 0 : k);
-    HessType Hess = HessType::Zero(    // Hessian (second derivative) of val w.r.t. the active variable vector.
-                dynamic_mode_ ? 0 : (with_hessian ? k : 0),
-                dynamic_mode_ ? 0 : (with_hessian ? k : 0));
+    HessType Hess = HessType::Zero(    // Hessian (second derivative) of val w.r.t. the active variable vector. Might be restricted to smaller (rectangular) block.
+                dynamic_mode_ ? 0 : (with_hessian ? hess_rows : 0),
+                dynamic_mode_ ? 0 : (with_hessian ? hess_cols : 0));
 };
 
 // ///////////////////////////////////////////////////////////////////////////
@@ -1346,12 +1374,12 @@ Eigen::Matrix<ScalarT, rows, cols> to_passive(
 }
 
 // ///////////////////////////////////////////////////////////////////////////
-// TinyAD::Scalar typedefs
+// TinyAD::Scalar typedefs: Float, Double, LongDouble
 // ///////////////////////////////////////////////////////////////////////////
 
-template <int k, bool with_hessian = true> using Float = Scalar<k, float, with_hessian>;
-template <int k, bool with_hessian = true> using Double = Scalar<k, double, with_hessian>;
-template <int k, bool with_hessian = true> using LongDouble = Scalar<k, long double, with_hessian>;
+template <int k, bool with_hessian = true, int hess_row_start = 0, int hess_col_start = 0, int hess_rows = k, int hess_cols = k> using Float = Scalar<k, float, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols>;
+template <int k, bool with_hessian = true, int hess_row_start = 0, int hess_col_start = 0, int hess_rows = k, int hess_cols = k> using Double = Scalar<k, double, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols>;
+template <int k, bool with_hessian = true, int hess_row_start = 0, int hess_col_start = 0, int hess_rows = k, int hess_cols = k> using LongDouble = Scalar<k, long double, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols>;
 
 } // namespace TinyAD
 
@@ -1365,13 +1393,13 @@ namespace Eigen
  * See https://eigen.tuxfamily.org/dox/TopicCustomizing_CustomScalar.html
  * and https://eigen.tuxfamily.org/dox/structEigen_1_1NumTraits.html
  */
-template<int k, typename PassiveT, bool with_hessian>
-struct NumTraits<TinyAD::Scalar<k, PassiveT, with_hessian>>
+template<int k, typename PassiveT, bool with_hessian, int hess_row_start, int hess_col_start, int hess_rows, int hess_cols>
+struct NumTraits<TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols>>
         : NumTraits<PassiveT>
 {
-    typedef TinyAD::Scalar<k, PassiveT, with_hessian> Real;
-    typedef TinyAD::Scalar<k, PassiveT, with_hessian> NonInteger;
-    typedef TinyAD::Scalar<k, PassiveT, with_hessian> Nested;
+    typedef TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols> Real;
+    typedef TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols> NonInteger;
+    typedef TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols> Nested;
 
     enum
     {
@@ -1389,16 +1417,16 @@ struct NumTraits<TinyAD::Scalar<k, PassiveT, with_hessian>>
  * Let Eigen know that binary operations between TinyAD::Scalar and T are allowed,
  * and that the return type is TinyAD::Scalar.
  */
-template<typename BinaryOp, int k, typename PassiveT, bool with_hessian>
-struct ScalarBinaryOpTraits<TinyAD::Scalar<k, PassiveT, with_hessian>, PassiveT, BinaryOp>
+template<typename BinaryOp, int k, typename PassiveT, bool with_hessian, int hess_row_start, int hess_col_start, int hess_rows, int hess_cols>
+struct ScalarBinaryOpTraits<TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols>, PassiveT, BinaryOp>
 {
-    typedef TinyAD::Scalar<k, PassiveT, with_hessian> ReturnType;
+    typedef TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols> ReturnType;
 };
 
-template<typename BinaryOp, int k, typename PassiveT, bool with_hessian>
-struct ScalarBinaryOpTraits<PassiveT, TinyAD::Scalar<k, PassiveT, with_hessian>, BinaryOp>
+template<typename BinaryOp, int k, typename PassiveT, bool with_hessian, int hess_row_start, int hess_col_start, int hess_rows, int hess_cols>
+struct ScalarBinaryOpTraits<PassiveT, TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols>, BinaryOp>
 {
-    typedef TinyAD::Scalar<k, PassiveT, with_hessian> ReturnType;
+    typedef TinyAD::Scalar<k, PassiveT, with_hessian, hess_row_start, hess_col_start, hess_rows, hess_cols> ReturnType;
 };
 
 } // namespace Eigen

--- a/tests/ExceptionTest.cc
+++ b/tests/ExceptionTest.cc
@@ -27,7 +27,7 @@ TEST(ExceptionTest, ExceptionTest)
     {
         auto [f, g, H] = func.eval_with_hessian_proj(Vector1(0.0));
     }
-    catch (const std::exception& ex)
+    catch (const std::exception&)
     {
         caught_first_exception = true;
     }
@@ -36,7 +36,7 @@ TEST(ExceptionTest, ExceptionTest)
     {
         auto [f, g, H] = func.eval_with_hessian_proj(Vector1(0.0));
     }
-    catch (const std::exception& ex)
+    catch (const std::exception&)
     {
         caught_second_exception = true;
     }

--- a/tests/ScalarTestHessianBlock.cc
+++ b/tests/ScalarTestHessianBlock.cc
@@ -1,0 +1,100 @@
+﻿/*
+ * This file is part of TinyAD and released under the MIT license.
+ * Author: Patrick Schmidt
+ */
+#define _USE_MATH_DEFINES // Required for M_PI on Windows
+
+#include <gtest/gtest.h>
+#include <TinyAD/Scalar.hh>
+#include <TinyAD/Utils/Out.hh>
+#include <TinyAD/Utils/Helpers.hh>
+
+template <typename T>
+T f(
+    const T& x1, const T& x2,
+    const T& y1, const T& y2, const T& y3)
+{
+    // From https://github.com/patr-schm/TinyAD/issues/13
+    const auto r1 = x1-y1;
+    const auto r2 = x2-y2;
+    const auto d = r1*r1 + r2*r2;
+    return y3*d;
+}
+
+template <typename PassiveT>
+void test_hess_block_1()
+{
+    PassiveT x1 = 1;
+    PassiveT x2 = 2;
+    PassiveT y1 = 3;
+    PassiveT y2 = 4;
+    PassiveT y3 = 5;
+
+    // Compute full Hessian
+    using ADFull = TinyAD::Scalar<5, PassiveT>;
+    Eigen::Matrix<ADFull,5,1> x_full = ADFull::make_active({x1, x2, y1, y2, y3});
+    ADFull f_ad_full = f(x_full[0], x_full[1], x_full[2], x_full[3], x_full[4]);
+
+    // Compute truncated Hessian (2-by-3 block ddf/dxdy)
+    using ADTrunc = TinyAD::Scalar<5, PassiveT, true, 0, 2, 2, 3>;
+    Eigen::Matrix<ADTrunc, 5, 1> x_trunc = ADTrunc::make_active({x1, x2, y1, y2, y3});
+    ADTrunc f_ad_trunc = f(x_trunc[0], x_trunc[1], x_trunc[2], x_trunc[3], x_trunc[4]);
+
+    TINYAD_ASSERT_EPS_MAT(f_ad_trunc.Hess, f_ad_full.Hess.block(0, 2, 2, 3), 1e-16);
+}
+
+TEST(ScalarTestHessianBlock, HessianBlock1Float) { test_hess_block_1<float>(); }
+TEST(ScalarTestHessianBlock, HessianBlock1Double) { test_hess_block_1<double>(); }
+TEST(ScalarTestHessianBlock, HessianBlock1LongDouble) { test_hess_block_1<long double>(); }
+
+template <typename T, typename PassiveT>
+T symm_dirich(const Eigen::Matrix<T, 6, 1>& _x, const Eigen::Matrix<PassiveT, 6, 1>& _x_rest)
+{
+    const Eigen::Matrix<PassiveT, 2, 1> ar(_x_rest[0], _x_rest[1]);
+    const Eigen::Matrix<PassiveT, 2, 1> br(_x_rest[2], _x_rest[3]);
+    const Eigen::Matrix<PassiveT, 2, 1> cr(_x_rest[4], _x_rest[5]);
+    const Eigen::Matrix<PassiveT, 2, 2> Mr = TinyAD::col_mat(br - ar, cr - ar);
+
+    const Eigen::Matrix<T, 2, 1> a(_x[0], _x[1]);
+    const Eigen::Matrix<T, 2, 1> b(_x[2], _x[3]);
+    const Eigen::Matrix<T, 2, 1> c(_x[4], _x[5]);
+    const Eigen::Matrix<T, 2, 2> M = TinyAD::col_mat(b - a, c - a);
+
+    const Eigen::Matrix<T, 2, 2> J = M * Mr.inverse();
+    const PassiveT area = 1.0;
+
+    return area * (J.squaredNorm() + J.inverse().squaredNorm());
+}
+
+template <typename PassiveT, int hess_row_start, int hess_col_start, int hess_rows, int hess_cols>
+void test_hessian_block_symmetric_dirichlet()
+{
+    // Passive rest-state triangle ar, br, cr
+    const Eigen::Matrix<PassiveT, 2, 1> ar(1.0, 1.0);
+    const Eigen::Matrix<PassiveT, 2, 1> br(2.0, 1.0);
+    const Eigen::Matrix<PassiveT, 2, 1> cr(1.0, 2.0);
+    const Eigen::Matrix<PassiveT, 2, 2> Mr = TinyAD::col_mat(br - ar, cr - ar);
+
+    const Eigen::Matrix<PassiveT, 6, 1> x_rest = { 1.0, 1.0, 2.0, 1.0, 1.0, 2.0 };
+    const Eigen::Matrix<PassiveT, 6, 1> x_init = { 10.0, 1.0, 15.0, 3.0, 2.0, 2.0 };
+
+    // Compute full 6-by-6 Hessian
+    using ADFull = TinyAD::Scalar<6, PassiveT>;
+    const Eigen::Matrix<PassiveT, 6, 6> H_full = symm_dirich(ADFull::make_active(x_init), x_rest).Hess;
+
+    // Compute a Hessian block only and compare
+    using ADBlock = TinyAD::Scalar<6, PassiveT, true, hess_row_start, hess_col_start, hess_rows, hess_cols>;
+    const Eigen::Matrix<PassiveT, hess_rows, hess_cols> H_block = symm_dirich(ADBlock::make_active(x_init), x_rest).Hess;
+
+    TINYAD_ASSERT_EPS_MAT(H_block, H_full.block(hess_row_start, hess_col_start, hess_rows, hess_cols), 1e-16);
+}
+
+TEST(ScalarTestHessianBlock, HessianBlockSymmetricDirichletDouble)
+{
+    test_hessian_block_symmetric_dirichlet<double, 0, 0, 0, 0>();
+    test_hessian_block_symmetric_dirichlet<double, 0, 0, 6, 6>();
+    test_hessian_block_symmetric_dirichlet<double, 0, 0, 3, 1>();
+    test_hessian_block_symmetric_dirichlet<double, 0, 0, 1, 3>();
+    test_hessian_block_symmetric_dirichlet<double, 2, 2, 2, 2>();
+    test_hessian_block_symmetric_dirichlet<double, 1, 4, 5, 2>();
+}


### PR DESCRIPTION
Hessian computation in TinyAD::Scalar can now be restricted to a sub block for speedup. Merge feature request from #13.